### PR TITLE
Supported custom I2C instance

### DIFF
--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -143,7 +143,7 @@ bool LiquidCrystal_I2C::home(){
 }
 
 bool LiquidCrystal_I2C::setCursor(uint8_t col, uint8_t row){
-	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
+	int row_offsets[] = { 0x00, 0x40, 0x14 -(20 - _cols), 0x54 -(20 - _cols)};
 	if (row > _rows) {
 		row = _rows-1;    // we count rows starting w/0
 	}

--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -57,19 +57,19 @@ LiquidCrystal_I2C::LiquidCrystal_I2C(uint8_t lcd_addr, uint8_t lcd_cols, uint8_t
 {}
 
 #if defined(ESP8266)
-void LiquidCrystal_I2C::begin(uint8_t sda, uint8_t scl){
-	_wire.begin(sda,scl);
-	init();
+bool LiquidCrystal_I2C::begin(uint8_t sda, uint8_t scl){
+	return _wire.begin(sda,scl)
+	    && init();
 }
 
 #else
-void LiquidCrystal_I2C::begin(){
-	_wire.begin();
-	init();
+bool LiquidCrystal_I2C::begin(){
+	return _wire.begin()
+	    && init();
 }
 #endif
 
-void LiquidCrystal_I2C::init(){
+bool LiquidCrystal_I2C::init(){
 
 	_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
 
@@ -88,7 +88,7 @@ void LiquidCrystal_I2C::init(){
 	delay(50);
 
 	// Now we pull both RS and R/W low to begin commands
-	expanderWrite(_backlightval);	// reset expanderand turn backlight off (Bit 8 =1)
+	if (!expanderWrite(_backlightval)) return false;	// reset expanderand turn backlight off (Bit 8 =1)
 	delay(1000);
 
 	//put the LCD into 4 bit mode
@@ -96,139 +96,142 @@ void LiquidCrystal_I2C::init(){
 	// figure 24, pg 46
 
 	// we start in 8bit mode, try to set 4 bit mode
-	write4bits(0x03 << 4);
+	if (!write4bits(0x03 << 4)) return false;
 	delayMicroseconds(4500); // wait min 4.1ms
 
 	// second try
-	write4bits(0x03 << 4);
+	if (!write4bits(0x03 << 4)) return false;
 	delayMicroseconds(4500); // wait min 4.1ms
 
 	// third go!
-	write4bits(0x03 << 4);
+	if (!write4bits(0x03 << 4)) return false;
 	delayMicroseconds(150);
 
 	// finally, set to 4-bit interface
-	write4bits(0x02 << 4);
+	if (!write4bits(0x02 << 4)) return false;
 
 	// set # lines, font size, etc.
-	command(LCD_FUNCTIONSET | _displayfunction);
+	if (!command(LCD_FUNCTIONSET | _displayfunction)) return false;
 
 	// turn the display on with no cursor or blinking default
 	_displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
 	display();
 
 	// clear it off
-	clear();
+	if (!clear()) return false;
 
 	// Initialize to default text direction (for roman languages)
 	_displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
 
 	// set the entry mode
-	command(LCD_ENTRYMODESET | _displaymode);
+	if (!command(LCD_ENTRYMODESET | _displaymode)) return false;
 
-	home();
+	return home();
 }
 
 /********** high level commands, for the user! */
-void LiquidCrystal_I2C::clear(){
-	command(LCD_CLEARDISPLAY);// clear display, set cursor position to zero
+bool LiquidCrystal_I2C::clear(){
+	if (!command(LCD_CLEARDISPLAY)) return false;// clear display, set cursor position to zero
 	delayMicroseconds(2000);  // this command takes a long time!
+    return true;
 }
 
-void LiquidCrystal_I2C::home(){
-	command(LCD_RETURNHOME);  // set cursor position to zero
+bool LiquidCrystal_I2C::home(){
+	if (!command(LCD_RETURNHOME)) return false;  // set cursor position to zero
 	delayMicroseconds(2000);  // this command takes a long time!
+    return true;
 }
 
-void LiquidCrystal_I2C::setCursor(uint8_t col, uint8_t row){
+bool LiquidCrystal_I2C::setCursor(uint8_t col, uint8_t row){
 	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
 	if (row > _rows) {
 		row = _rows-1;    // we count rows starting w/0
 	}
-	command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
+	return command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
 }
 
 // Turn the display on/off (quickly)
-void LiquidCrystal_I2C::noDisplay() {
+bool LiquidCrystal_I2C::noDisplay() {
 	_displaycontrol &= ~LCD_DISPLAYON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+	return command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
-void LiquidCrystal_I2C::display() {
+bool LiquidCrystal_I2C::display() {
 	_displaycontrol |= LCD_DISPLAYON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+	return command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 
 // Turns the underline cursor on/off
-void LiquidCrystal_I2C::noCursor() {
+bool LiquidCrystal_I2C::noCursor() {
 	_displaycontrol &= ~LCD_CURSORON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+	return command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
-void LiquidCrystal_I2C::cursor() {
+bool LiquidCrystal_I2C::cursor() {
 	_displaycontrol |= LCD_CURSORON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+	return command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 
 // Turn on and off the blinking cursor
-void LiquidCrystal_I2C::noBlink() {
+bool LiquidCrystal_I2C::noBlink() {
 	_displaycontrol &= ~LCD_BLINKON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+	return command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
-void LiquidCrystal_I2C::blink() {
+bool LiquidCrystal_I2C::blink() {
 	_displaycontrol |= LCD_BLINKON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+	return command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 
 // These commands scroll the display without changing the RAM
-void LiquidCrystal_I2C::scrollDisplayLeft(void) {
-	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVELEFT);
+bool LiquidCrystal_I2C::scrollDisplayLeft(void) {
+	return command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVELEFT);
 }
-void LiquidCrystal_I2C::scrollDisplayRight(void) {
-	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVERIGHT);
+bool LiquidCrystal_I2C::scrollDisplayRight(void) {
+	return command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVERIGHT);
 }
 
 // This is for text that flows Left to Right
-void LiquidCrystal_I2C::leftToRight(void) {
+bool LiquidCrystal_I2C::leftToRight(void) {
 	_displaymode |= LCD_ENTRYLEFT;
-	command(LCD_ENTRYMODESET | _displaymode);
+	return command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // This is for text that flows Right to Left
-void LiquidCrystal_I2C::rightToLeft(void) {
+bool LiquidCrystal_I2C::rightToLeft(void) {
 	_displaymode &= ~LCD_ENTRYLEFT;
-	command(LCD_ENTRYMODESET | _displaymode);
+	return command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // This will 'right justify' text from the cursor
-void LiquidCrystal_I2C::autoscroll(void) {
+bool LiquidCrystal_I2C::autoscroll(void) {
 	_displaymode |= LCD_ENTRYSHIFTINCREMENT;
-	command(LCD_ENTRYMODESET | _displaymode);
+	return command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // This will 'left justify' text from the cursor
-void LiquidCrystal_I2C::noAutoscroll(void) {
+bool LiquidCrystal_I2C::noAutoscroll(void) {
 	_displaymode &= ~LCD_ENTRYSHIFTINCREMENT;
-	command(LCD_ENTRYMODESET | _displaymode);
+	return command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // Allows us to fill the first 8 CGRAM locations
 // with custom characters
-void LiquidCrystal_I2C::createChar(uint8_t location, uint8_t charmap[]) {
+bool LiquidCrystal_I2C::createChar(uint8_t location, uint8_t charmap[]) {
 	location &= 0x7; // we only have 8 locations 0-7
-	command(LCD_SETCGRAMADDR | (location << 3));
+	if (!command(LCD_SETCGRAMADDR | (location << 3))) return false;
 	for (int i=0; i<8; i++) {
-		write(charmap[i]);
+		if (!write(charmap[i])) return false;
 	}
+    return true;
 }
 
 // Turn the (optional) backlight off/on
-void LiquidCrystal_I2C::noBacklight(void) {
+bool LiquidCrystal_I2C::noBacklight(void) {
 	_backlightval=LCD_NOBACKLIGHT;
-	expanderWrite(0);
+	return expanderWrite(0);
 }
 
-void LiquidCrystal_I2C::backlight(void) {
+bool LiquidCrystal_I2C::backlight(void) {
 	_backlightval=LCD_BACKLIGHT;
-	expanderWrite(0);
+	return expanderWrite(0);
 }
 
 // Get status of blacklight
@@ -238,58 +241,61 @@ bool LiquidCrystal_I2C::getBacklight() {
 
 /*********** mid level commands, for sending data/cmds */
 
-inline void LiquidCrystal_I2C::command(uint8_t value) {
-	send(value, 0);
+inline bool LiquidCrystal_I2C::command(uint8_t value) {
+	return send(value, 0);
 }
 
 inline size_t LiquidCrystal_I2C::write(uint8_t value) {
-	send(value, Rs);
+	return send(value, Rs);
 }
 
 
 /************ low level data pushing commands **********/
 
 // write either command or data
-void LiquidCrystal_I2C::send(uint8_t value, uint8_t mode) {
+bool LiquidCrystal_I2C::send(uint8_t value, uint8_t mode) {
 	uint8_t highnib=value&0xf0;
 	uint8_t lownib=(value<<4)&0xf0;
-	write4bits((highnib)|mode);
-	write4bits((lownib)|mode);
+	return write4bits((highnib)|mode)
+	    && write4bits((lownib)|mode);
 }
 
-void LiquidCrystal_I2C::write4bits(uint8_t value) {
-	expanderWrite(value);
-	pulseEnable(value);
+bool LiquidCrystal_I2C::write4bits(uint8_t value) {
+	return expanderWrite(value)
+	    && pulseEnable(value);
 }
 
-void LiquidCrystal_I2C::expanderWrite(uint8_t _data){
+bool LiquidCrystal_I2C::expanderWrite(uint8_t _data){
 	_wire.beginTransmission(_addr);
-	_wire.write((int)(_data) | _backlightval);
-	_wire.endTransmission();
+	const auto size = _wire.write((int)(_data) | _backlightval);
+    if (size != 1) return false;
+	const auto err = _wire.endTransmission();
+    return err == 0;
 }
 
-void LiquidCrystal_I2C::pulseEnable(uint8_t _data){
-	expanderWrite(_data | En);	// En high
+bool LiquidCrystal_I2C::pulseEnable(uint8_t _data){
+	if (!expanderWrite(_data | En)) return false;	// En high
 	delayMicroseconds(1);		// enable pulse must be >450ns
 
-	expanderWrite(_data & ~En);	// En low
+	if (!expanderWrite(_data & ~En)) return false;	// En low
 	delayMicroseconds(50);		// commands need > 37us to settle
+    return true;
 }
 
-void LiquidCrystal_I2C::load_custom_character(uint8_t char_num, uint8_t *rows){
-	createChar(char_num, rows);
+bool LiquidCrystal_I2C::load_custom_character(uint8_t char_num, uint8_t *rows){
+	return createChar(char_num, rows);
 }
 
-void LiquidCrystal_I2C::setBacklight(uint8_t new_val){
+bool LiquidCrystal_I2C::setBacklight(uint8_t new_val){
 	if (new_val) {
-		backlight();		// turn backlight on
+		return backlight();		// turn backlight on
 	} else {
-		noBacklight();		// turn backlight off
+		return noBacklight();		// turn backlight off
 	}
 }
 
-void LiquidCrystal_I2C::printstr(const char c[]){
+size_t LiquidCrystal_I2C::printstr(const char c[]){
 	//This function is not identical to the function used for "real" I2C displays
 	//it's here so the user sketch doesn't have to be changed
-	print(c);
+	return print(c);
 }

--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -17,7 +17,7 @@ CHANGELOG:
     -> Add new function "begin(uint8_t sda, uint8_t scl)"
     -> Add new function "init()"
 * 02/07/2017 (1.1v):
-    -> Add new function "getBacklight()" get status of backlight 
+    -> Add new function "getBacklight()" get status of backlight
 
 ***************************************************************************
 Copyright(2017) by: Lucas Maziero.
@@ -28,40 +28,43 @@ Copyright(2017) by: Lucas Maziero.
 // When the display powers up, it is configured as follows:
 //
 // 1. Display clear
-// 2. Function set: 
-//    DL = 1; 8-bit interface data 
-//    N = 0; 1-line display 
-//    F = 0; 5x8 dot character font 
-// 3. Display on/off control: 
-//    D = 0; Display off 
-//    C = 0; Cursor off 
-//    B = 0; Blinking off 
-// 4. Entry mode set: 
+// 2. Function set:
+//    DL = 1; 8-bit interface data
+//    N = 0; 1-line display
+//    F = 0; 5x8 dot character font
+// 3. Display on/off control:
+//    D = 0; Display off
+//    C = 0; Cursor off
+//    B = 0; Blinking off
+// 4. Entry mode set:
 //    I/D = 1; Increment by 1
-//    S = 0; No shift 
+//    S = 0; No shift
 //
 // Note, however, that resetting the Arduino doesn't reset the LCD, so we
 // can't assume that its in that state when a sketch starts (and the
 // LiquidCrystal constructor is called).
 
-LiquidCrystal_I2C::LiquidCrystal_I2C(uint8_t lcd_addr, uint8_t lcd_cols, uint8_t lcd_rows, uint8_t charsize)
-{
-	_addr = lcd_addr;
-	_cols = lcd_cols;
-	_rows = lcd_rows;
-	_charsize = charsize;
-	_backlightval = LCD_BACKLIGHT;
-}
+LiquidCrystal_I2C::LiquidCrystal_I2C(uint8_t lcd_addr, uint8_t lcd_cols, uint8_t lcd_rows, uint8_t charsize, TwoWire & wire):
+	_addr(lcd_addr),
+    _displayfunction(0),
+    _displaycontrol(0),
+    _displaymode(0),
+	_cols(lcd_cols),
+	_rows(lcd_rows),
+	_charsize(charsize),
+	_backlightval(LCD_BACKLIGHT),
+    _wire(wire)
+{}
 
 #if defined(ESP8266)
 void LiquidCrystal_I2C::begin(uint8_t sda, uint8_t scl){
-	Wire.begin(sda,scl);
+	_wire.begin(sda,scl);
 	init();
 }
 
 #else
 void LiquidCrystal_I2C::begin(){
-	Wire.begin();
+	_wire.begin();
 	init();
 }
 #endif
@@ -82,7 +85,7 @@ void LiquidCrystal_I2C::init(){
 	// SEE PAGE 45/46 FOR INITIALIZATION SPECIFICATION!
 	// according to datasheet, we need at least 40ms after power rises above 2.7V
 	// before sending commands. Arduino can turn on way befer 4.5V so we'll wait 50
-	delay(50); 
+	delay(50);
 
 	// Now we pull both RS and R/W low to begin commands
 	expanderWrite(_backlightval);	// reset expanderand turn backlight off (Bit 8 =1)
@@ -101,28 +104,28 @@ void LiquidCrystal_I2C::init(){
 	delayMicroseconds(4500); // wait min 4.1ms
 
 	// third go!
-	write4bits(0x03 << 4); 
+	write4bits(0x03 << 4);
 	delayMicroseconds(150);
 
 	// finally, set to 4-bit interface
-	write4bits(0x02 << 4); 
+	write4bits(0x02 << 4);
 
 	// set # lines, font size, etc.
-	command(LCD_FUNCTIONSET | _displayfunction);  
-	
+	command(LCD_FUNCTIONSET | _displayfunction);
+
 	// turn the display on with no cursor or blinking default
 	_displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
 	display();
-	
+
 	// clear it off
 	clear();
-	
+
 	// Initialize to default text direction (for roman languages)
 	_displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
-	
+
 	// set the entry mode
 	command(LCD_ENTRYMODESET | _displaymode);
-	
+
 	home();
 }
 
@@ -251,7 +254,7 @@ void LiquidCrystal_I2C::send(uint8_t value, uint8_t mode) {
 	uint8_t highnib=value&0xf0;
 	uint8_t lownib=(value<<4)&0xf0;
 	write4bits((highnib)|mode);
-	write4bits((lownib)|mode); 
+	write4bits((lownib)|mode);
 }
 
 void LiquidCrystal_I2C::write4bits(uint8_t value) {
@@ -259,16 +262,16 @@ void LiquidCrystal_I2C::write4bits(uint8_t value) {
 	pulseEnable(value);
 }
 
-void LiquidCrystal_I2C::expanderWrite(uint8_t _data){                                        
-	Wire.beginTransmission(_addr);
-	Wire.write((int)(_data) | _backlightval);
-	Wire.endTransmission();   
+void LiquidCrystal_I2C::expanderWrite(uint8_t _data){
+	_wire.beginTransmission(_addr);
+	_wire.write((int)(_data) | _backlightval);
+	_wire.endTransmission();
 }
 
 void LiquidCrystal_I2C::pulseEnable(uint8_t _data){
 	expanderWrite(_data | En);	// En high
 	delayMicroseconds(1);		// enable pulse must be >450ns
-	
+
 	expanderWrite(_data & ~En);	// En low
 	delayMicroseconds(50);		// commands need > 37us to settle
 }
@@ -287,6 +290,6 @@ void LiquidCrystal_I2C::setBacklight(uint8_t new_val){
 
 void LiquidCrystal_I2C::printstr(const char c[]){
 	//This function is not identical to the function used for "real" I2C displays
-	//it's here so the user sketch doesn't have to be changed 
+	//it's here so the user sketch doesn't have to be changed
 	print(c);
 }

--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -101,72 +101,72 @@ public:
 	 * Set the LCD display in the correct begin state, must be called before anything else is done.
 	 */
 #if defined(ESP8266)
-	void begin(uint8_t sda = SDA , uint8_t scl = SCL); // Int with pin default ESP8266 I2C
+	bool begin(uint8_t sda = SDA , uint8_t scl = SCL); // Int with pin default ESP8266 I2C
 #else
-	void begin(); // Int with pin default ARDUINO
+	bool begin(); // Int with pin default ARDUINO
 #endif
 
 	 /**
 	  * Remove all the characters currently shown. Next print/write operation will start
 	  * from the first position on LCD display.
 	  */
-	void clear();
+	bool clear();
 
 	/**
 	 * Next print/write operation will will start from the first position on the LCD display.
 	 */
-	void home();
+	bool home();
 
 	 /**
 	  * Do not show any characters on the LCD display. Backlight state will remain unchanged.
 	  * Also all characters written on the display will return, when the display in enabled again.
 	  */
-	void noDisplay();
+	bool noDisplay();
 
 	/**
 	 * Show the characters on the LCD display, this is the normal behaviour. This method should
 	 * only be used after noDisplay() has been used.
 	 */
-	void display();
+	bool display();
 
 	/**
 	 * Do not blink the cursor indicator.
 	 */
-	void noBlink();
+	bool noBlink();
 
 	/**
 	 * Start blinking the cursor indicator.
 	 */
-	void blink();
+	bool blink();
 
 	/**
 	 * Do not show a cursor indicator.
 	 */
-	void noCursor();
+	bool noCursor();
 
 	/**
  	 * Show a cursor indicator, cursor can blink on not blink. Use the
 	 * methods blink() and noBlink() for changing cursor blink.
 	 */
-	void cursor();
+	bool cursor();
 
-	void scrollDisplayLeft();
-	void scrollDisplayRight();
-	void printLeft();
-	void printRight();
-	void leftToRight();
-	void rightToLeft();
-	void shiftIncrement();
-	void shiftDecrement();
-	void noBacklight();
-	void backlight();
+	bool scrollDisplayLeft();
+	bool scrollDisplayRight();
+	bool printLeft();
+	bool printRight();
+	bool leftToRight();
+	bool rightToLeft();
+	bool shiftIncrement();
+	bool shiftDecrement();
+	bool noBacklight();
+	bool backlight();
 	bool getBacklight();
-	void autoscroll();
-	void noAutoscroll();
-	void createChar(uint8_t, uint8_t[]);
-	void setCursor(uint8_t, uint8_t);
+	bool autoscroll();
+	bool noAutoscroll();
+	bool createChar(uint8_t, uint8_t[]);
+	bool setCursor(uint8_t, uint8_t);
 	virtual size_t write(uint8_t);
-	void command(uint8_t);
+	bool command(uint8_t);
 
 	inline void blink_on() { blink(); }
 	inline void blink_off() { noBlink(); }
@@ -174,16 +174,16 @@ public:
 	inline void cursor_off() { noCursor(); }
 
 // Compatibility API function aliases
-	void setBacklight(uint8_t new_val);				// alias for backlight() and nobacklight()
-	void load_custom_character(uint8_t char_num, uint8_t *rows);	// alias for createChar()
-	void printstr(const char[]);
+	bool setBacklight(uint8_t new_val);				// alias for backlight() and nobacklight()
+	bool load_custom_character(uint8_t char_num, uint8_t *rows);	// alias for createChar()
+	size_t printstr(const char[]);
 
 private:
-	void init();
-	void send(uint8_t, uint8_t);
-	void write4bits(uint8_t);
-	void expanderWrite(uint8_t);
-	void pulseEnable(uint8_t);
+	bool init();
+	bool send(uint8_t, uint8_t);
+	bool write4bits(uint8_t);
+	bool expanderWrite(uint8_t);
+	bool pulseEnable(uint8_t);
 	uint8_t _addr;
 	uint8_t _displayfunction;
 	uint8_t _displaycontrol;

--- a/LiquidCrystal_I2C.h
+++ b/LiquidCrystal_I2C.h
@@ -17,13 +17,13 @@ CHANGELOG:
     -> Add new function "begin(uint8_t sda, uint8_t scl)"
     -> Add new function "init()"
 * 02/07/2017 (1.1v):
-    -> Add new function "getBacklight()" get status of backlight 
+    -> Add new function "getBacklight()" get status of backlight
 
 ***************************************************************************
 Copyright(2017) by: Lucas Maziero.
 **************************************************************************/
 
-#ifndef LIQUID_CRYSTAL_I2C_H 
+#ifndef LIQUID_CRYSTAL_I2C_H
 #define LIQUID_CRYSTAL_I2C_H
 
 #include <Arduino.h>
@@ -95,15 +95,15 @@ public:
 	 * @param lcd_rows	Number of rows your LCD display has.
 	 * @param charsize	The size in dots that the display has, use LCD_5x10DOTS or LCD_5x8DOTS.
 	 */
-	LiquidCrystal_I2C(uint8_t lcd_addr, uint8_t lcd_cols, uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS);
+	LiquidCrystal_I2C(uint8_t lcd_addr, uint8_t lcd_cols, uint8_t lcd_rows, uint8_t charsize = LCD_5x8DOTS, TwoWire & wire = Wire);
 
 	/**
 	 * Set the LCD display in the correct begin state, must be called before anything else is done.
 	 */
 #if defined(ESP8266)
-	void begin(uint8_t sda = SDA , uint8_t scl = SCL); // Int with pin default ESP8266 I2C 
+	void begin(uint8_t sda = SDA , uint8_t scl = SCL); // Int with pin default ESP8266 I2C
 #else
-	void begin(); // Int with pin default ARDUINO 
+	void begin(); // Int with pin default ARDUINO
 #endif
 
 	 /**
@@ -111,7 +111,7 @@ public:
 	  * from the first position on LCD display.
 	  */
 	void clear();
-	  
+
 	/**
 	 * Next print/write operation will will start from the first position on the LCD display.
 	 */
@@ -122,22 +122,22 @@ public:
 	  * Also all characters written on the display will return, when the display in enabled again.
 	  */
 	void noDisplay();
-	  
+
 	/**
 	 * Show the characters on the LCD display, this is the normal behaviour. This method should
 	 * only be used after noDisplay() has been used.
-	 */ 
+	 */
 	void display();
 
 	/**
 	 * Do not blink the cursor indicator.
 	 */
 	void noBlink();
-	 
+
 	/**
 	 * Start blinking the cursor indicator.
-	 */ 
-	void blink();	 
+	 */
+	void blink();
 
 	/**
 	 * Do not show a cursor indicator.
@@ -147,7 +147,7 @@ public:
 	/**
  	 * Show a cursor indicator, cursor can blink on not blink. Use the
 	 * methods blink() and noBlink() for changing cursor blink.
-	 */ 
+	 */
 	void cursor();
 
 	void scrollDisplayLeft();
@@ -162,9 +162,9 @@ public:
 	void backlight();
 	bool getBacklight();
 	void autoscroll();
-	void noAutoscroll(); 
+	void noAutoscroll();
 	void createChar(uint8_t, uint8_t[]);
-	void setCursor(uint8_t, uint8_t); 
+	void setCursor(uint8_t, uint8_t);
 	virtual size_t write(uint8_t);
 	void command(uint8_t);
 
@@ -177,7 +177,7 @@ public:
 	void setBacklight(uint8_t new_val);				// alias for backlight() and nobacklight()
 	void load_custom_character(uint8_t char_num, uint8_t *rows);	// alias for createChar()
 	void printstr(const char[]);
-	 
+
 private:
 	void init();
 	void send(uint8_t, uint8_t);
@@ -192,6 +192,7 @@ private:
 	uint8_t _rows;
 	uint8_t _charsize;
 	uint8_t _backlightval;
+    TwoWire & _wire;
 };
 
 #endif // LIQUID_CRYSTAL_I2C_H

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=LiquidCrystal_I2C
+version=1.1.0
+author= Lucas Maziero
+maintainer= Lucas Maziero
+sentence=This is a library for using LCDs via I2C
+paragraph=This is a library for using LCDs via I2C
+category=Signal Input/Output
+url=https://github.com/lucasmaziero/LiquidCrystal_I2C
+architectures=*


### PR DESCRIPTION
Hi,

this pr proposes:
* The feature to *optionally* pass a custom I2C instance, instead of using the default `Wire`
* The methods now return a boolean, to check whether its invocation has been a success.
* The changes are backward compatible
* As bonus, added `library.properties` to improve library installation (especially with `arduino-cli`)

Regards
